### PR TITLE
FUSETOOLS2-1496 - allow manual build trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
as we are consuming snapshots (yes, not ideal), it can be useful to
trigger the build manually to ensure latest snapshots is picked up.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>