### PR TITLE
Use 0.6.0-SNAPSHOT for Debug Adapter Server

### DIFF
--- a/com.github.camel-tooling.dap.eclipse.client/pom.xml
+++ b/com.github.camel-tooling.dap.eclipse.client/pom.xml
@@ -14,7 +14,7 @@
 	<packaging>eclipse-plugin</packaging>
 	
 	<properties>
-		<camel-lsp-server-version>0.4.0-SNAPSHOT</camel-lsp-server-version>
+		<camel-lsp-server-version>0.6.0-SNAPSHOT</camel-lsp-server-version>
 		<tycho-version>0.26.0</tycho-version>
 	</properties>
 	


### PR DESCRIPTION
requires https://github.com/camel-tooling/camel-debug-adapter/pull/141