### PR TITLE
Use a GitHub group to assign Dependabot reviewer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,13 +6,11 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   reviewers:
-  - apupier
-  - joshiraez
+  - camel-tooling/vs-code-dependabot-reviewers
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
   reviewers:
-  - apupier
-  - joshiraez
+  - camel-tooling/vs-code-dependabot-reviewers


### PR DESCRIPTION
Signed-off-by: Aurélien Pupier <apupier@redhat.com>